### PR TITLE
Fix: Dashboard template errors and improve data handling

### DIFF
--- a/real_data_dashboard.py
+++ b/real_data_dashboard.py
@@ -529,15 +529,20 @@ DASHBOARD_TEMPLATE = """
                                             <span class="badge bg-info">{{ account.sku_name }}</span>
                                         </td>
                                         <td>
+                                            {% if account.get('creation_time') %}
                                             <small>{{ account.creation_time[:10] }}</small>
                                             <br><small class="text-muted">{{ account.creation_time[11:19] }}</small>
+                                            {% else %}
+                                            <small class="text-muted">N/A</small>
+                                            <br><small class="text-muted">--:--:--</small>
+                                            {% endif %}
                                         </td>
                                         <td>
                                             <small>
-                                                {% if account.primary_endpoints.blob %}
+                                                {% if account.get('primary_endpoints', {}).get('blob') %}
                                                 <i class="fas fa-cube text-primary me-1"></i>Blob<br>
                                                 {% endif %}
-                                                {% if account.primary_endpoints.file %}
+                                                {% if account.get('primary_endpoints', {}).get('file') %}
                                                 <i class="fas fa-file text-success me-1"></i>File
                                                 {% endif %}
                                             </small>


### PR DESCRIPTION
##  Bug Fixes

### Problem Solved:
- Fixed jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'creation_time'
- Resolved Internal Server Error 500 when accessing dashboard
- Improved template safety for missing data fields

### Changes Made:
-  Added safe dictionary access using .get() method for creation_time field
-  Fixed primary_endpoints nested dictionary access with safe fallbacks  
-  Added graceful handling for missing data fields in template
-  Prevented crashes when Azure data structure varies
-  Ensured dashboard renders correctly with real Azure data

### Testing:
-  Dashboard now loads successfully at http://localhost:5000
-  HTTP 200 status instead of 500 Internal Server Error
-  All 3 storage accounts display correctly
-  Real Azure data integration works properly

### Files Changed:
- eal_data_dashboard.py - Template fixes and safe data access

Closes dashboard rendering issues and improves system reliability.